### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It gathers Exif, IPTC, JFIF and TIFF properties and places them into a single ``
 Usage
 -----
 
-1. [Install using Cocoapods](http://cocoadocs.org/docsets/Bravo/) or by adding the files under the ```/Source``` directory to your target.
+1. [Install using CocoaPods](http://cocoadocs.org/docsets/Bravo/) or by adding the files under the ```/Source``` directory to your target.
 
 2. To retrieve the metadata of an image, extract said image to a ```NSData``` object and use the method ```-extractMetadataFromJPEG:``` on it:
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
